### PR TITLE
Adding rename table test

### DIFF
--- a/src/main/java/com/akolb/HMSBenchmark.java
+++ b/src/main/java/com/akolb/HMSBenchmark.java
@@ -37,7 +37,6 @@ import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Formatter;
@@ -60,6 +59,7 @@ import static com.akolb.HMSBenchmarks.benchmarkListDatabases;
 import static com.akolb.HMSBenchmarks.benchmarkListManyPartitions;
 import static com.akolb.HMSBenchmarks.benchmarkListPartition;
 import static com.akolb.HMSBenchmarks.benchmarkListTables;
+import static com.akolb.HMSBenchmarks.benchmarkRenameTable;
 import static com.akolb.HMSBenchmarks.benchmarkTableCreate;
 import static com.akolb.HMSTool.OPT_CONF;
 import static com.akolb.HMSTool.OPT_DATABASE;
@@ -207,6 +207,8 @@ final class HMSBenchmark {
               () -> benchmarkCreatePartitions(bench, client, db, tbl, instances))
           .add("dropPartitions" + '.' + instances,
               () -> benchmarkDropPartitions(bench, client, db, tbl, instances))
+          .add("renameTable",
+              () -> benchmarkRenameTable(bench, client, db, tbl, tbl + "_renamed", instances))
           .runMatching(patterns);
 
       if (cmd.hasOption(OPT_CSV)) {

--- a/src/main/java/com/akolb/HMSBenchmarks.java
+++ b/src/main/java/com/akolb/HMSBenchmarks.java
@@ -285,6 +285,37 @@ class HMSBenchmarks {
     }
   }
 
+  static DescriptiveStatistics benchmarkRenameTable(MicroBenchmark bench,
+                                                    final HMSClient client,
+                                                    final String dbName,
+                                                    final String tableName,
+                                                    final String newTableName,
+                                                    int count) {
+    createPartitionedTable(client, dbName, tableName);
+    try {
+      addManyPartitionsNoException(client, dbName, tableName,
+          Collections.singletonList("d"), count);
+      Table oldTable = client.getTable(dbName, tableName);
+      oldTable.getSd().setLocation("");
+      Table newTable = oldTable.deepCopy();
+      newTable.setTableName(newTableName);
+
+      return bench.measure(
+          null,
+          () -> {
+              client.alterTableNoException(oldTable.getDbName(), oldTable.getTableName(), newTable);
+              client.alterTableNoException(newTable.getDbName(), newTable.getTableName(), oldTable);
+            },
+          null
+      );
+    } catch (TException e) {
+      e.printStackTrace();
+      return new DescriptiveStatistics();
+    } finally {
+      client.dropTableNoException(dbName, tableName);
+    }
+  }
+
   private static void createManyTables(HMSClient client, int howMany, String dbName, String format) {
     List<FieldSchema> columns = createSchema(new ArrayList<>(Arrays.asList("name", "string")));
     List<FieldSchema> partitions = createSchema(new ArrayList<>(Arrays.asList("date", "string")));

--- a/src/main/java/com/akolb/HMSClient.java
+++ b/src/main/java/com/akolb/HMSClient.java
@@ -374,6 +374,16 @@ final class HMSClient implements AutoCloseable {
     }
   }
 
+  void alterTableNoException(@NotNull String dbName, @NotNull String tableName,
+                             @NotNull Table newTable) {
+    try {
+      client.alter_table(dbName, tableName, newTable);
+    } catch (TException e) {
+      throw  new RuntimeException(e);
+    }
+  }
+
+
   private TTransport open(HiveConf conf, @NotNull URI uri) throws
       TException, IOException, LoginException {
     boolean useSasl = conf.getBoolVar(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL);


### PR DESCRIPTION
Since customers has problems with renaming tables, created a test to measure how much time it takes to rename a table with multiple partitions.

The test actually do 2 renames, so the end state of the test is the same as the start state. This way we do not have to create and drop the table every time.

(This is my first pull request, so feel free to guide me if something can be done better :) )