### PR TITLE
Add support for benchmarking table renames #3

### DIFF
--- a/src/main/java/com/akolb/HMSBenchmark.java
+++ b/src/main/java/com/akolb/HMSBenchmark.java
@@ -37,7 +37,6 @@ import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Formatter;
@@ -60,6 +59,7 @@ import static com.akolb.HMSBenchmarks.benchmarkListDatabases;
 import static com.akolb.HMSBenchmarks.benchmarkListManyPartitions;
 import static com.akolb.HMSBenchmarks.benchmarkListPartition;
 import static com.akolb.HMSBenchmarks.benchmarkListTables;
+import static com.akolb.HMSBenchmarks.benchmarkRenameTable;
 import static com.akolb.HMSBenchmarks.benchmarkTableCreate;
 import static com.akolb.HMSTool.OPT_CONF;
 import static com.akolb.HMSTool.OPT_DATABASE;
@@ -207,6 +207,10 @@ final class HMSBenchmark {
               () -> benchmarkCreatePartitions(bench, client, db, tbl, instances))
           .add("dropPartitions" + '.' + instances,
               () -> benchmarkDropPartitions(bench, client, db, tbl, instances))
+          .add("renameTable",
+              () -> benchmarkRenameTable(bench, client, db, tbl, 1))
+          .add("renameTable" + '.' + instances,
+              () -> benchmarkRenameTable(bench, client, db, tbl, instances))
           .runMatching(patterns);
 
       if (cmd.hasOption(OPT_CSV)) {

--- a/src/main/java/com/akolb/HMSClient.java
+++ b/src/main/java/com/akolb/HMSClient.java
@@ -374,6 +374,20 @@ final class HMSClient implements AutoCloseable {
     }
   }
 
+  void alterTable(@NotNull String dbName, @NotNull String tableName, @NotNull Table newTable)
+      throws TException {
+    client.alter_table(dbName, tableName, newTable);
+  }
+
+  void alterTableNoException(@NotNull String dbName, @NotNull String tableName,
+                             @NotNull Table newTable) {
+    try {
+      alterTable(dbName, tableName, newTable);
+    } catch (TException e) {
+      throw  new RuntimeException(e);
+    }
+  }
+
   private TTransport open(HiveConf conf, @NotNull URI uri) throws
       TException, IOException, LoginException {
     boolean useSasl = conf.getBoolVar(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL);


### PR DESCRIPTION
Using single argument variation of measure.
Added comment to state why it is using 2 renames.
Added single partition version of the rename benchmark